### PR TITLE
Implement better sync commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           flake8 .
           mypy .
+          isort .
       #    pytest
       - name: Build package
         run: |

--- a/an_at_sync/actionnetwork.py
+++ b/an_at_sync/actionnetwork.py
@@ -223,13 +223,8 @@ class ActionNetworkApi:
         next_href = event["_links"]["osdi:attendances"]["href"]
 
         while next_href:
-            response = self.session.get(next_href)
-            attendances_body = response.json()
-
-            for attendance in attendances_body["_embedded"]["osdi:attendances"]:
-                person_url = attendance["_links"]["osdi:person"]["href"]
-                person_body = self.session.get(person_url).json()
-                yield person_body
+            attendances_body = self.session.get(next_href).json()
+            yield from attendances_body["_embedded"]["osdi:attendances"]
 
             try:
                 next_href = attendances_body["_links"]["next"]["href"]

--- a/an_at_sync/cli.py
+++ b/an_at_sync/cli.py
@@ -1,8 +1,16 @@
 import json
 from pathlib import Path
-from typer import Option, Typer
 
+from typer import Argument, Option, Typer
+
+from an_at_sync.model import BaseEvent
 from an_at_sync.program import Program, ProgramSettings
+
+
+class Pipedream:
+    def __init__(self, steps: dict) -> None:
+        self.steps = steps
+
 
 main = Typer()
 
@@ -16,8 +24,17 @@ ConfigOption = Option(
 )
 
 
-@main.command("sync")
-def sync(config: Path = ConfigOption):
+@main.command("init")
+def init():
+    pass
+
+
+sync = Typer()
+main.add_typer(sync, name="sync")
+
+
+@sync.command("events")
+def events(config: Path = ConfigOption, sync_rsvps: bool = Option(False, "--rsvps")):
     config_file = Program.load_config(config)
 
     program = Program(
@@ -27,14 +44,21 @@ def sync(config: Path = ConfigOption):
         rsvp_class=config_file.RSVP,
     )
 
-    for sync_result in program.sync_events():
-        program.write_result(sync_result)
+    for event_result in program.sync_events():
+        program.write_result(event_result)
+
+        if (
+            sync_rsvps
+            and event_result.status != "failed"
+            and isinstance(event_result.instance, BaseEvent)
+        ):
+            for rsvp_result in program.sync_rsvps_from_event(event_result.instance):
+                program.write_result(rsvp_result)
 
 
 @main.command("webhook")
 def webhook(
-    config: Path = ConfigOption,
-    webhook: Path = Option(
+    webhook_path: Path = Argument(
         ...,
         help="JSON file containing webhook body",
         exists=True,
@@ -42,17 +66,12 @@ def webhook(
         dir_okay=False,
         resolve_path=True,
     ),
+    config: Path = ConfigOption,
 ):
     config_file = Program.load_config(config)
 
-    program = Program(
-        settings=ProgramSettings(),
-        activist_class=config_file.Activist,
-        event_class=config_file.Event,
-        rsvp_class=config_file.RSVP,
-    )
-    with open(webhook) as f:
-        webhook_body = json.load(f)
+    with open(webhook_path) as f:
+        trigger = json.load(f)
 
-    for result in program.handle_webhook(webhook_body):
-        program.write_result(result)
+    pd = Pipedream(steps={"trigger": trigger})
+    config_file.handler(pd)

--- a/an_at_sync/model.py
+++ b/an_at_sync/model.py
@@ -1,26 +1,25 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Type, TypeVar
+from typing import Any, Dict, Generic, Iterable, List, Optional, Type, TypeVar, Union
 
-if TYPE_CHECKING:
-    from .program import Program
-
+from pyairtable import Table
+from pyairtable.formulas import match
 from pydantic import BaseModel as PydanticModel
 
-T = TypeVar("T")
+from an_at_sync.actionnetwork import ActionNetworkApi
+
+T = TypeVar("T", bound="BaseModel")
 
 
 class BaseModel(PydanticModel):
-    pass
-
-
-class AirtableTransformerModel(BaseModel):
     @classmethod
     @abstractmethod
-    def from_actionnetwork(
-        cls: Type[T], source: dict, custom_fields: Optional[dict] = None
-    ) -> T:
+    def from_actionnetwork(cls: Type[T], source: dict, **kwargs: Any) -> T:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def display_name(self) -> str:
         raise NotImplementedError()
 
     @abstractmethod
@@ -38,22 +37,13 @@ class AirtableTransformerModel(BaseModel):
         return f"<{self.__class__.__name__} {params}>"
 
 
-class BaseActivist(AirtableTransformerModel):
+class BaseActivist(BaseModel):
     pass
 
 
 class BaseRSVP(BaseModel):
-    """
-    Note: Can't use AirtableTransformerModel because
-    the base methods don't work for this pivot table.
-    """
-
     activist: BaseActivist
     event: "BaseEvent"
-
-    @abstractmethod
-    def id_column(self) -> str:
-        raise NotImplementedError()
 
     @abstractmethod
     def activist_column(self) -> str:
@@ -64,20 +54,173 @@ class BaseRSVP(BaseModel):
         raise NotImplementedError()
 
 
-class BaseEvent(AirtableTransformerModel):
-    rsvps: Optional[List[BaseRSVP]]
-
-    def set_rsvps(self, rsvps: List[BaseRSVP]) -> None:
-        self.rsvps = rsvps
-
-    def add_rsvp(self, rsvp: BaseRSVP) -> None:
-        if not self.rsvps:
-            self.rsvps = []
-        self.rsvps.append(rsvp)
-
-    def finalize(self, program: "Program", event) -> Iterable[BaseEvent]:
-        self.set_rsvps(list(program._get_rsvps_from_event(event)))
+class BaseEvent(BaseModel):
+    def postprocess(self) -> Iterable[BaseEvent]:
         yield self
+
+    def load_rsvps(
+        self,
+        an_event: dict,
+        events: "EventRepository",
+        rsvps: "RSVPRepository",
+        activists: "ActivistRepository",
+    ) -> Iterable[BaseRSVP]:
+        for an_attendance in rsvps.an.get_attendances_from_event(an_event):
+            person_url = an_attendance["_links"]["osdi:person"]["href"]
+            activist = activists.from_actionnetwork_url(person_url)
+            yield rsvps.klass.from_actionnetwork(
+                an_attendance,
+                event=self,
+                activist=activist,
+                event_record=events.get_airtable_record(self),
+                activist_record=activists.get_airtable_record(activist),
+            )
 
 
 BaseRSVP.update_forward_refs()
+
+M = TypeVar("M", bound="BaseModel")
+KOD = TypeVar("KOD")
+VOD = TypeVar("VOD")
+
+
+class ObjectDict(Generic[KOD, VOD]):
+    """
+    This is obviously missing a lot to be a full-fledged dict
+    but this works for what we want to do for now.
+    """
+
+    def __init__(self) -> None:
+        self.keys: List[KOD] = []
+        self.values: List[VOD] = []
+
+    def __setitem__(self, key, val):
+        for i, existing_key in enumerate(self.keys):
+            if existing_key == key:
+                self.values[i] = val
+        else:
+            self.keys.append(key)
+            self.values.append(val)
+
+    def get(self, key) -> Union[VOD, None]:
+        for i, existing_key in enumerate(self.keys):
+            if existing_key == key:
+                return self.values[i]
+
+        return None
+
+    def __repr__(self):
+        return f"<ObjectDict keys={str(self.keys)} values={str(self.values)}>"
+
+
+class BaseRepository(Generic[M]):
+    def __init__(self, an: ActionNetworkApi, at: Table, klass: Type[M]) -> None:
+        self.an = an
+        self.at = at
+        self.klass = klass
+        self.model_to_at = ObjectDict[M, dict]()
+        self.at_to_model = ObjectDict[dict, M]()
+        self.model_to_an = ObjectDict[M, dict]()
+        self.an_to_model = ObjectDict[dict, M]()
+
+    def get_airtable_record(self, model: M):
+        at_model = self.model_to_at.get(model)
+        if not at_model:
+            at_model = self.at.first(formula=match(model.pk()))
+            if at_model:
+                self._associate_model(model, at_model=at_model)
+        return at_model
+
+    def insert_airtable_record(self, model: M, **kwargs):
+        return self.at.create(model.to_airtable())
+
+    def update_airtable_record(self, model: M):
+        airtable_record = self.get_airtable_record(model)
+        if airtable_record is None:
+            raise Exception("Cannot update record that does not exist")
+        return self.at.update(airtable_record["id"], model.to_airtable())
+
+    def should_update_airtable_record(self, model: M):
+        airtable_record = self.get_airtable_record(model)
+        if airtable_record is None:
+            raise Exception("Cannot update record that does not exist")
+        fields = airtable_record["fields"]
+        update = model.to_airtable()
+
+        def empty_str_to_none(val):
+            return None if val == "" else val
+
+        # Handle situations where an empty string on the AN side maps
+        # to None on the AT side, such that an update would produce
+        # no changes but this would other mark them as different
+        return {key: empty_str_to_none(update.get(key)) for key in update} != {
+            key: empty_str_to_none(fields.get(key)) for key in update
+        }
+
+    def from_actionnetwork_url(self, url: str, **kwargs) -> M:
+        an_model = self.an.session.get(url).json()
+        model = self.an_to_model.get(an_model)
+        if not model:
+            model = self.klass.from_actionnetwork(an_model, **kwargs)
+            self._associate_model(model, an_model=an_model)
+        return model
+
+    def _associate_model(
+        self,
+        model: M,
+        *,
+        an_model: Optional[dict] = None,
+        at_model: Optional[dict] = None,
+    ):
+        if an_model:
+            self.an_to_model[an_model] = model
+            self.model_to_an[model] = an_model
+
+        if at_model:
+            self.at_to_model[at_model] = model
+            self.model_to_at[model] = at_model
+
+
+class EventRepository(BaseRepository[BaseEvent]):
+    def all_from_actionnetwork(self) -> Iterable[BaseEvent]:
+        for an_event in self.an.get_all_events():
+            event = self.an_to_model.get(an_event)
+            if not event:
+                event = self.klass.from_actionnetwork(an_event)
+                self._associate_model(event, an_model=an_event)
+            yield from event.postprocess()
+
+
+class ActivistRepository(BaseRepository[BaseActivist]):
+    def all_from_actionnetwork(self) -> Iterable[BaseActivist]:
+        for an_activist in self.an.get_all_activists():
+            activist = self.an_to_model.get(an_activist)
+            if not activist:
+                activist = self.klass.from_actionnetwork(an_activist)
+                self._associate_model(activist, an_model=an_activist)
+            yield activist
+
+
+class RSVPRepository(BaseRepository[BaseRSVP]):
+    def insert_airtable_record(self, model: BaseRSVP, **kwargs):
+        return self.at.create(
+            {
+                **model.to_airtable(),
+                model.activist_column(): [kwargs["activist_record"]["id"]],
+                model.event_column(): [kwargs["event_record"]["id"]],
+            }
+        )
+
+    def from_actionnetwork_for_event(
+        self, event: BaseEvent, events: EventRepository, activists: ActivistRepository
+    ) -> Iterable[BaseRSVP]:
+        an_event = events.model_to_an.get(event)
+        if an_event is None:
+            raise Exception(
+                "Event passed to RSVPRepository#from_actionnetwork_for_event was not loaded from AN;"
+                "Loading from AN for AT source not yet supported"
+            )
+
+        yield from event.load_rsvps(
+            an_event, events=events, rsvps=self, activists=activists
+        )

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
 # Always prefer setuptools over distutils
-from setuptools import setup
-
 # To use a consistent encoding
 from codecs import open
 from os import path
+
+from setuptools import setup
 
 # The directory containing this file
 HERE = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
The goal of this PR is to implement `an_at_sync sync events`. In the process, I cleaned up a bunch of warts, removed some hardcoding, and generally just made the API more consistent. Here's an overview:

1. Created repositories for each of the models in the application.

    This provides an interface for interacting with the models on multiple systems.
    These also track the source of a model, so if we create an Event, we can retrieve the
    ActionNetwork model that we sourced it from, in order to grab extra information
    from it without needing to attach it to the model.

2. Extract all of the API interaction logic from the `Program` model

    The `Program` now stitches together the methods from the repositories to produce
    a logical flow, and wraps everything in `try/except` to map down to a shared
    SyncResult, and really simplifies what each both is actually responsible for.

3. Harmonize the RSVP model

    We had a lot of hard-coded logic in the way we handled RSVPs, because it's got
    some special behavior, in that it's a pivot table between the other two models.
    Making this work consistently was a little challenging but this exposes the
    attendance model to the `from_actionnetwork` method, making `RSVP` more
    like the other models. The RSVPRepository also absorbs some of this extra logic.

4. Implement the sync command & update webhook command

    The `sync` cli command now instead has a subcommand, `events`, with a flag,
    `--rsvps`, which allows you to control whether you're syncing the events, or the
    events plus its RSVPs.

5. Split `finalize` into `postprocess` & `load_rsvps`.

    This was required because we needed to break up creating the event & loading the
    rsvps now that we have a flag to toggle it. This still enables us to split up a single
    ActionNetwork events into multiple AT events.

    **Note**: I'm not entirely sure this plays nicely with the way the caching structure
    works. We may want to reconsider either the repository metadata setup, the API for
    hooking into this, or both.

6. Run webhook against config.py's webhook

    If you're trying to debug your webhook, you can copy it down, run
    `an_at_sync webhook webhook.json`, and verify it against a mock pipedream
    instance with your trigger body loaded.

7. Dummy `init` command

    Still to come.

8. Add isort to ci

    Fix all files.

Fixes #17.