### PR TITLE
Load models from module

### DIFF
--- a/an_at_sync/cli.py
+++ b/an_at_sync/cli.py
@@ -6,12 +6,6 @@ from typer import Argument, Option, Typer
 from an_at_sync.model import BaseEvent
 from an_at_sync.program import Program, ProgramSettings
 
-
-class Pipedream:
-    def __init__(self, steps: dict) -> None:
-        self.steps = steps
-
-
 main = Typer()
 
 ConfigOption = Option(
@@ -35,13 +29,8 @@ main.add_typer(sync, name="sync")
 
 @sync.command("events")
 def events(config: Path = ConfigOption, sync_rsvps: bool = Option(False, "--rsvps")):
-    config_file = Program.load_config(config)
-
     program = Program(
         settings=ProgramSettings(),
-        activist_class=config_file.Activist,
-        event_class=config_file.Event,
-        rsvp_class=config_file.RSVP,
     )
 
     for event_result in program.sync_events():
@@ -65,13 +54,12 @@ def webhook(
         file_okay=True,
         dir_okay=False,
         resolve_path=True,
-    ),
-    config: Path = ConfigOption,
+    )
 ):
-    config_file = Program.load_config(config)
+    with webhook_path.open() as f:
+        body = json.load(f)
 
-    with open(webhook_path) as f:
-        trigger = json.load(f)
-
-    pd = Pipedream(steps={"trigger": trigger})
-    config_file.handler(pd)
+    program = Program(
+        settings=ProgramSettings(),
+    )
+    program.handle_webhook(body)


### PR DESCRIPTION
Clean up `webhook` command to pass the body in directly to the program rather than through the handler (which we are removing as the approach). This enables us to depend directly on the AN webhook body, making the program more portable to different environments.